### PR TITLE
[RFC] Add IRC pane 

### DIFF
--- a/static/js/webchat.js
+++ b/static/js/webchat.js
@@ -6,7 +6,6 @@ function fitWebchatToWindow() {
 }
 
 function insertWebchat() {
-	console.log("WEEB CHAT");
 	var frame = document.createElement('iframe');
 	frame.setAttribute('id', 'webchat');
 	frame.setAttribute('src', iframeURL);

--- a/static/js/webfort.js
+++ b/static/js/webfort.js
@@ -32,8 +32,10 @@ function connect() {
 
 function fitCanvasToWindow() {
 	if (active) {
-		canvas.width = window.innerWidth & (~15);
-		canvas.height = (window.innerHeight - 20) & (~15);
+		// FIXME: Canvas resizing meshes poorly with the chatbox.
+		//canvas.width = window.innerWidth & (~15);
+		//canvas.height = (window.innerHeight - 20) & (~15);
+
 
 		var data = new Uint8Array([
 				112,
@@ -128,10 +130,12 @@ function onMessage(evt) {
 		var neww = data[2] * 16;
 		var newh = data[3] * 16;
 		// resizeCanvas
+		/*
 		if (neww != canvas.width || newh != canvas.height) {
 			canvas.width = neww;
 			canvas.height = newh;
 		}
+		*/
 
 		renderUpdate(ctx, data);
 

--- a/static/webfort.html
+++ b/static/webfort.html
@@ -33,16 +33,18 @@
 .col-left {
   width: 75%;
 }
+canvas {
+  width: 100%;
+  height: auto;
+}
   </style>
   <script src="/js/stats.min.js"></script>
 </head>
 
 <body class="webfort-body">
-  <div class="col col-left">
+  <div id="game-container" class="col col-left">
     <div id="status" style="">Loading...</div>
-    <center>
-      <canvas id="myCanvas" width="1280" height="400"></canvas>
-    </center>
+    <canvas id="myCanvas" width="1280" height="400"></canvas>
   </div>
 
   <div id="webchat-container" class="col col-right">


### PR DESCRIPTION
Resolves #2.
In the old code, the size of the DF window streched to fit the size of the controlling player's screen. Since part of that screen is now covered with a chat window, that had to get fixed somehow. To make this PR work I did the dumbest thing that could possibly work, which is hardcode the size to the default and scale the canvas size afterward to fit the window width. This is probably not ideal, but it's a step in the right direction  IMO because previously, no scaling was done at all, and screens could grow to server-crashing sizes (see https://archive.moe/vg/thread/83566642/#83576774)
