### PR TITLE
Spectator Support

### DIFF
--- a/static/js/webfort.js
+++ b/static/js/webfort.js
@@ -57,7 +57,9 @@ function onOpen(evt) {
 function onClose(evt) {
 	setStatus('Disconnected', 'red');
 }
-
+function toggleSpectator()  {
+	websocket.send(new Uint8Array([116]));
+}
 function renderQueueStatus(qpos, almostOver) {
 	if (qpos === 0) {
 		if (!active) {


### PR DESCRIPTION
Adds the spectator property for the client on the server.
A client is a spectator by default.
Adds a function to toggle spectator status for the client.
